### PR TITLE
Feature/u1141 support ssl ca

### DIFF
--- a/include/binlog_api.h
+++ b/include/binlog_api.h
@@ -114,6 +114,10 @@ public:
   {
     return ERR_OK;
   }
+  virtual int set_ssl_ca(const char *filepath)
+  {
+    return ERR_OK;
+  }
 };
 
 class Content_handler;
@@ -179,6 +183,16 @@ public:
    */
   unsigned long get_position(std::string &filename);
   int disconnect();
+
+  /**
+   * Set ssl_ca file
+   *
+   * @param filename ssl ca file path
+   *
+   * @retval 0 Success
+   * @retval >0 Error code
+   */
+  int set_ssl_ca(const char *filepath);
 };
 
 }

--- a/include/binlog_api.h
+++ b/include/binlog_api.h
@@ -114,7 +114,7 @@ public:
   {
     return ERR_OK;
   }
-  virtual int set_ssl_ca(const char *filepath)
+  virtual int set_ssl_ca(const std::string& filepath)
   {
     return ERR_OK;
   }
@@ -192,7 +192,7 @@ public:
    * @retval 0 Success
    * @retval >0 Error code
    */
-  int set_ssl_ca(const char *filepath);
+  int set_ssl_ca(const std::string& filepath);
 };
 
 }

--- a/include/binlog_driver.h
+++ b/include/binlog_driver.h
@@ -77,6 +77,17 @@ public:
                            unsigned long *position_ptr) = 0;
 
   virtual int disconnect()= 0;
+
+  /**
+   * Set ssl_ca file
+   *
+   * @param filename ssl ca file path
+   *
+   * @retval 0 Success
+   * @retval >0 Error code
+   */
+  virtual int set_ssl_ca(const char *filepath)= 0;
+
   Binary_log_event* parse_event(std::istream &sbuff, Log_event_header *header);
 
 protected:

--- a/include/binlog_driver.h
+++ b/include/binlog_driver.h
@@ -86,7 +86,7 @@ public:
    * @retval 0 Success
    * @retval >0 Error code
    */
-  virtual int set_ssl_ca(const char *filepath)= 0;
+  virtual int set_ssl_ca(const std::string& filepath)= 0;
 
   Binary_log_event* parse_event(std::istream &sbuff, Log_event_header *header);
 

--- a/include/file_driver.h
+++ b/include/file_driver.h
@@ -52,6 +52,7 @@ public:
     int set_position(const std::string &str, unsigned long position);
     int get_position(std::string *str, unsigned long *position);
     int connect(const std::string &filename, ulong offset);
+    int set_ssl_ca(const char *filepath);
 private:
 
     unsigned long m_binlog_file_size;

--- a/include/file_driver.h
+++ b/include/file_driver.h
@@ -52,7 +52,7 @@ public:
     int set_position(const std::string &str, unsigned long position);
     int get_position(std::string *str, unsigned long *position);
     int connect(const std::string &filename, ulong offset);
-    int set_ssl_ca(const char *filepath);
+    int set_ssl_ca(const std::string& filepath);
 private:
 
     unsigned long m_binlog_file_size;

--- a/include/tcp_driver.h
+++ b/include/tcp_driver.h
@@ -47,7 +47,10 @@ public:
                       const std::string& host, uint port)
       : Binary_log_driver("", 4), m_host(host), m_user(user), m_passwd(passwd),
         m_port(port), m_waiting_event(0),
-        m_total_bytes_transferred(0), m_shutdown(false)
+        m_total_bytes_transferred(0), m_shutdown(false),
+        opt_use_ssl(0), opt_ssl_capath(0), opt_ssl_cert(0),
+        opt_ssl_cipher(0), opt_ssl_key(0), opt_ssl_crl(0),
+        opt_ssl_crlpath(0), opt_ssl_verify_server_cert(0)
     {
     }
 
@@ -124,6 +127,11 @@ private:
 
     bool m_shutdown;
 
+    int sync_connect_and_authenticate(MYSQL *mysql, const std::string &user,
+        const std::string &passwd,
+        const std::string &host, uint port,
+        long offset= 4);
+
     /**
      * each bin log event starts with a 19 byte long header
      * We use this sturcture every time we initiate an async
@@ -158,6 +166,18 @@ private:
     MYSQL *m_mysql;
     uint64_t m_total_bytes_transferred;
 
+    /*
+     * SSL configuration
+     */
+    my_bool opt_use_ssl;
+    char *opt_ssl_ca;
+    char *opt_ssl_capath;
+    char *opt_ssl_cert;
+    char *opt_ssl_cipher;
+    char *opt_ssl_key;
+    char *opt_ssl_crl;
+    char *opt_ssl_crlpath;
+    my_bool opt_ssl_verify_server_cert;
 
 };
 
@@ -172,23 +192,6 @@ bool fetch_master_status(MYSQL *mysql, std::string *filename,
 
 bool fetch_binlog_name_and_size(MYSQL *mysql, std::map<std::string, unsigned long> *binlog_map);
 
-/*
- * SSL configuration
- */
-static my_bool opt_use_ssl= 0;
-static char *opt_ssl_ca= 0;
-static char *opt_ssl_capath= 0;
-static char *opt_ssl_cert= 0;
-static char *opt_ssl_cipher= 0;
-static char *opt_ssl_key= 0;
-static char *opt_ssl_crl= 0;
-static char *opt_ssl_crlpath= 0;
-static my_bool opt_ssl_verify_server_cert= 0;
-
-int sync_connect_and_authenticate(MYSQL *mysql, const std::string &user,
-                                  const std::string &passwd,
-                                  const std::string &host, uint port,
-                                  long offset= 4);
 } }
 
 #endif	/* TCP_DRIVER_INCLUDED */

--- a/include/tcp_driver.h
+++ b/include/tcp_driver.h
@@ -82,6 +82,7 @@ public:
     int disconnect(void);
 
     int get_position(std::string *str, unsigned long *position);
+    int set_ssl_ca(const char *filepath);
     const std::string& user() const { return m_user; }
     const std::string& password() const { return m_passwd; }
     const std::string& host() const { return m_host; }
@@ -156,6 +157,8 @@ private:
     uint m_port;
     MYSQL *m_mysql;
     uint64_t m_total_bytes_transferred;
+
+
 };
 
 /**
@@ -169,12 +172,23 @@ bool fetch_master_status(MYSQL *mysql, std::string *filename,
 
 bool fetch_binlog_name_and_size(MYSQL *mysql, std::map<std::string, unsigned long> *binlog_map);
 
+/*
+ * SSL configuration
+ */
+static my_bool opt_use_ssl= 0;
+static char *opt_ssl_ca= 0;
+static char *opt_ssl_capath= 0;
+static char *opt_ssl_cert= 0;
+static char *opt_ssl_cipher= 0;
+static char *opt_ssl_key= 0;
+static char *opt_ssl_crl= 0;
+static char *opt_ssl_crlpath= 0;
+static my_bool opt_ssl_verify_server_cert= 0;
+
 int sync_connect_and_authenticate(MYSQL *mysql, const std::string &user,
                                   const std::string &passwd,
                                   const std::string &host, uint port,
                                   long offset= 4);
 } }
-
-
 
 #endif	/* TCP_DRIVER_INCLUDED */

--- a/include/tcp_driver.h
+++ b/include/tcp_driver.h
@@ -82,7 +82,7 @@ public:
     int disconnect(void);
 
     int get_position(std::string *str, unsigned long *position);
-    int set_ssl_ca(const char *filepath);
+    int set_ssl_ca(const std::string& filepath);
     const std::string& user() const { return m_user; }
     const std::string& password() const { return m_passwd; }
     const std::string& host() const { return m_host; }

--- a/include/tcp_driver.h
+++ b/include/tcp_driver.h
@@ -47,7 +47,8 @@ public:
                       const std::string& host, uint port)
       : Binary_log_driver("", 4), m_host(host), m_user(user), m_passwd(passwd),
         m_port(port), m_waiting_event(0),
-        m_total_bytes_transferred(0), m_shutdown(false)
+        m_total_bytes_transferred(0), m_shutdown(false),
+        m_opt_use_ssl(0), m_opt_ssl_verify_server_cert(0)
     {
     }
 

--- a/include/tcp_driver.h
+++ b/include/tcp_driver.h
@@ -48,9 +48,9 @@ public:
       : Binary_log_driver("", 4), m_host(host), m_user(user), m_passwd(passwd),
         m_port(port), m_waiting_event(0),
         m_total_bytes_transferred(0), m_shutdown(false),
-        opt_use_ssl(0), opt_ssl_capath(0), opt_ssl_cert(0),
-        opt_ssl_cipher(0), opt_ssl_key(0), opt_ssl_crl(0),
-        opt_ssl_crlpath(0), opt_ssl_verify_server_cert(0)
+        m_opt_use_ssl(0), m_opt_ssl_capath(0), m_opt_ssl_cert(0),
+        m_opt_ssl_cipher(0), m_opt_ssl_key(0), m_opt_ssl_crl(0),
+        m_opt_ssl_crlpath(0), m_opt_ssl_verify_server_cert(0)
     {
     }
 
@@ -169,15 +169,15 @@ private:
     /*
      * SSL configuration
      */
-    my_bool opt_use_ssl;
-    char *opt_ssl_ca;
-    char *opt_ssl_capath;
-    char *opt_ssl_cert;
-    char *opt_ssl_cipher;
-    char *opt_ssl_key;
-    char *opt_ssl_crl;
-    char *opt_ssl_crlpath;
-    my_bool opt_ssl_verify_server_cert;
+    my_bool m_opt_use_ssl;
+    char *m_opt_ssl_ca;
+    char *m_opt_ssl_capath;
+    char *m_opt_ssl_cert;
+    char *m_opt_ssl_cipher;
+    char *m_opt_ssl_key;
+    char *m_opt_ssl_crl;
+    char *m_opt_ssl_crlpath;
+    my_bool m_opt_ssl_verify_server_cert;
 
 };
 

--- a/include/tcp_driver.h
+++ b/include/tcp_driver.h
@@ -129,7 +129,7 @@ private:
         const std::string &host, uint port,
         long offset= 4);
 
-    const char* opt_value(const std::string *opt_str);
+    const char* opt_value(const std::string& opt_str);
 
     /**
      * each bin log event starts with a 19 byte long header

--- a/include/tcp_driver.h
+++ b/include/tcp_driver.h
@@ -47,10 +47,7 @@ public:
                       const std::string& host, uint port)
       : Binary_log_driver("", 4), m_host(host), m_user(user), m_passwd(passwd),
         m_port(port), m_waiting_event(0),
-        m_total_bytes_transferred(0), m_shutdown(false),
-        m_opt_use_ssl(0), m_opt_ssl_capath(0), m_opt_ssl_cert(0),
-        m_opt_ssl_cipher(0), m_opt_ssl_key(0), m_opt_ssl_crl(0),
-        m_opt_ssl_crlpath(0), m_opt_ssl_verify_server_cert(0)
+        m_total_bytes_transferred(0), m_shutdown(false)
     {
     }
 
@@ -132,6 +129,8 @@ private:
         const std::string &host, uint port,
         long offset= 4);
 
+    const char* opt_value(const std::string *opt_str);
+
     /**
      * each bin log event starts with a 19 byte long header
      * We use this sturcture every time we initiate an async
@@ -170,13 +169,14 @@ private:
      * SSL configuration
      */
     my_bool m_opt_use_ssl;
-    char *m_opt_ssl_ca;
-    char *m_opt_ssl_capath;
-    char *m_opt_ssl_cert;
-    char *m_opt_ssl_cipher;
-    char *m_opt_ssl_key;
-    char *m_opt_ssl_crl;
-    char *m_opt_ssl_crlpath;
+    //char *m_opt_ssl_ca;
+    std::string m_opt_ssl_ca;
+    std::string m_opt_ssl_capath;
+    std::string m_opt_ssl_cert;
+    std::string m_opt_ssl_cipher;
+    std::string m_opt_ssl_key;
+    std::string m_opt_ssl_crl;
+    std::string m_opt_ssl_crlpath;
     my_bool m_opt_ssl_verify_server_cert;
 
 };

--- a/src/binary_log.cpp
+++ b/src/binary_log.cpp
@@ -134,4 +134,9 @@ int Binary_log::connect()
 {
   return m_driver->connect();
 }
+int Binary_log::set_ssl_ca(const char *filepath)
+{
+  return m_driver->set_ssl_ca(filepath);
+}
+
 }

--- a/src/binary_log.cpp
+++ b/src/binary_log.cpp
@@ -134,7 +134,7 @@ int Binary_log::connect()
 {
   return m_driver->connect();
 }
-int Binary_log::set_ssl_ca(const char *filepath)
+int Binary_log::set_ssl_ca(const std::string& filepath)
 {
   return m_driver->set_ssl_ca(filepath);
 }

--- a/src/file_driver.cpp
+++ b/src/file_driver.cpp
@@ -244,7 +244,7 @@ using namespace std;
     return ERR_EOF;
   }
 
-  int Binlog_file_driver::set_ssl_ca(const char *filepath)
+  int Binlog_file_driver::set_ssl_ca(const std::string& filepath)
   {
     return ERR_OK;
   }

--- a/src/file_driver.cpp
+++ b/src/file_driver.cpp
@@ -244,6 +244,11 @@ using namespace std;
     return ERR_EOF;
   }
 
+  int Binlog_file_driver::set_ssl_ca(const char *filepath)
+  {
+    return ERR_OK;
+  }
+
 }
 }
 

--- a/src/tcp_driver.cpp
+++ b/src/tcp_driver.cpp
@@ -167,10 +167,10 @@ int Binlog_tcp_driver::sync_connect_and_authenticate(MYSQL *conn, const std::str
    */
   if (m_opt_use_ssl)
   {
-    mysql_ssl_set(conn, opt_value(&m_opt_ssl_key), opt_value(&m_opt_ssl_cert), opt_value(&m_opt_ssl_ca),
-                        opt_value(&m_opt_ssl_capath), opt_value(&m_opt_ssl_cipher));
-    mysql_options(conn, MYSQL_OPT_SSL_CRL, opt_value(&m_opt_ssl_crl));
-    mysql_options(conn, MYSQL_OPT_SSL_CRLPATH, opt_value(&m_opt_ssl_crlpath));
+    mysql_ssl_set(conn, opt_value(m_opt_ssl_key), opt_value(m_opt_ssl_cert), opt_value(m_opt_ssl_ca),
+                        opt_value(m_opt_ssl_capath), opt_value(m_opt_ssl_cipher));
+    mysql_options(conn, MYSQL_OPT_SSL_CRL, opt_value(m_opt_ssl_crl));
+    mysql_options(conn, MYSQL_OPT_SSL_CRLPATH, opt_value(m_opt_ssl_crlpath));
   }
   mysql_options(conn,MYSQL_OPT_SSL_VERIFY_SERVER_CERT, (char*)&m_opt_ssl_verify_server_cert);
 
@@ -236,12 +236,12 @@ int Binlog_tcp_driver::sync_connect_and_authenticate(MYSQL *conn, const std::str
   return ERR_OK;
 }
 
-const char* Binlog_tcp_driver::opt_value(const std::string *opt_str)
+const char* Binlog_tcp_driver::opt_value(const std::string& opt_str)
 {
-  if (opt_str->empty())
+  if (opt_str.empty())
     return 0;
   else
-    return opt_str->c_str();
+    return opt_str.c_str();
 }
 
 void Binlog_tcp_driver::start_binlog_dump(const char *binlog_name,

--- a/src/tcp_driver.cpp
+++ b/src/tcp_driver.cpp
@@ -407,9 +407,9 @@ bool fetch_binlog_name_and_size(MYSQL *mysql, std::map<std::string, unsigned lon
   return ERR_OK;
 }
 
-int Binlog_tcp_driver::set_ssl_ca(const char *filepath)
+int Binlog_tcp_driver::set_ssl_ca(const std::string& filepath)
 {
-  m_opt_ssl_ca= std::string(filepath);
+  m_opt_ssl_ca= filepath;
   m_opt_use_ssl= 1;
   return ERR_OK;
 }

--- a/src/tcp_driver.cpp
+++ b/src/tcp_driver.cpp
@@ -140,7 +140,7 @@ int Binlog_tcp_driver::connect(const std::string& user,
   @retval ERR_OK          success
   @retval Other Value     failure
 */
-int sync_connect_and_authenticate(MYSQL *conn, const std::string &user,
+int Binlog_tcp_driver::sync_connect_and_authenticate(MYSQL *conn, const std::string &user,
                                   const std::string &passwd,
                                   const std::string &host, uint port,
                                   long offset)

--- a/src/tcp_driver.cpp
+++ b/src/tcp_driver.cpp
@@ -165,13 +165,13 @@ int Binlog_tcp_driver::sync_connect_and_authenticate(MYSQL *conn, const std::str
   /*
     Set SSL options
    */
-  if (opt_use_ssl)
+  if (m_opt_use_ssl)
   {
-    mysql_ssl_set(conn, opt_ssl_key, opt_ssl_cert, opt_ssl_ca, opt_ssl_capath, opt_ssl_cipher);
-    mysql_options(conn, MYSQL_OPT_SSL_CRL, opt_ssl_crl);
-    mysql_options(conn, MYSQL_OPT_SSL_CRLPATH, opt_ssl_crlpath);
+    mysql_ssl_set(conn, m_opt_ssl_key, m_opt_ssl_cert, m_opt_ssl_ca, m_opt_ssl_capath, m_opt_ssl_cipher);
+    mysql_options(conn, MYSQL_OPT_SSL_CRL, m_opt_ssl_crl);
+    mysql_options(conn, MYSQL_OPT_SSL_CRLPATH, m_opt_ssl_crlpath);
   }
-  mysql_options(conn,MYSQL_OPT_SSL_VERIFY_SERVER_CERT, (char*)&opt_ssl_verify_server_cert);
+  mysql_options(conn,MYSQL_OPT_SSL_VERIFY_SERVER_CERT, (char*)&m_opt_ssl_verify_server_cert);
 
 /*
   Attempts to establish a connection to a MySQL database engine
@@ -402,8 +402,8 @@ int Binlog_tcp_driver::set_ssl_ca(const char *filepath)
 {
   char *buf = new char[strlen(filepath)];
   strcpy(buf, filepath);
-  opt_ssl_ca= buf;
-  opt_use_ssl= 1;
+  m_opt_ssl_ca= buf;
+  m_opt_use_ssl= 1;
   return ERR_OK;
 }
 

--- a/src/tcp_driver.cpp
+++ b/src/tcp_driver.cpp
@@ -162,6 +162,16 @@ int sync_connect_and_authenticate(MYSQL *conn, const std::string &user,
 
   uchar version_split[3];
 
+  /*
+    Set SSL options
+   */
+  if (opt_use_ssl)
+  {
+    mysql_ssl_set(conn, opt_ssl_key, opt_ssl_cert, opt_ssl_ca, opt_ssl_capath, opt_ssl_cipher);
+    mysql_options(conn, MYSQL_OPT_SSL_CRL, opt_ssl_crl);
+    mysql_options(conn, MYSQL_OPT_SSL_CRLPATH, opt_ssl_crlpath);
+  }
+  mysql_options(conn,MYSQL_OPT_SSL_VERIFY_SERVER_CERT, (char*)&opt_ssl_verify_server_cert);
 
 /*
   Attempts to establish a connection to a MySQL database engine
@@ -387,4 +397,14 @@ bool fetch_binlog_name_and_size(MYSQL *mysql, std::map<std::string, unsigned lon
   }
   return ERR_OK;
 }
+
+int Binlog_tcp_driver::set_ssl_ca(const char *filepath)
+{
+  char *buf = new char[strlen(filepath)];
+  strcpy(buf, filepath);
+  opt_ssl_ca= buf;
+  opt_use_ssl= 1;
+  return ERR_OK;
+}
+
 }} // end namespace mysql::system

--- a/tests/replaybinlog.cpp
+++ b/tests/replaybinlog.cpp
@@ -262,7 +262,7 @@ int main(int argc, char** argv)
 
   if (argc > 2)
   {
-    binlog.set_ssl_ca(argv[2]);
+    binlog.set_ssl_ca(std::string(argv[2]));
   }
 
   /*

--- a/tests/replaybinlog.cpp
+++ b/tests/replaybinlog.cpp
@@ -251,7 +251,7 @@ public:
  */
 int main(int argc, char** argv)
 {
-  if (argc != 2)
+  if (argc < 2)
   {
     fprintf(stderr,"Usage:\n\treplaybinlog URL\n\nExample:"
             "\n\treplaybinlog mysql://root:mypasswd@127.0.0.1:3306\n\n");
@@ -260,6 +260,10 @@ int main(int argc, char** argv)
 
   mysql::Binary_log binlog(mysql::system::create_transport(argv[1]));
 
+  if (argc > 2)
+  {
+    binlog.set_ssl_ca(argv[2]);
+  }
 
   /*
     Attach a custom event parser which produces user defined events


### PR DESCRIPTION
Added `set_ssl_ca` api to `Binary_log` class to support SSL connection with a custom ssl ca certificate file. 

### How to test

```
cd mysql-replication-listener
mkdir build && cd build
cmake ..
make
./tests/replaybinlog "mysql://<username>:<password>@<mysql-server>" "<ssl-ca-cert-filepath>"
```