### PR TITLE
Make server_id configurable

### DIFF
--- a/src/tcp_driver.cpp
+++ b/src/tcp_driver.cpp
@@ -330,6 +330,17 @@ tcp::socket *sync_connect_and_authenticate(boost::asio::io_service &io_service, 
   boost::uint32_t val_server_id = 1;
   Protocol_chunk<boost::uint32_t> prot_server_id(val_server_id); // must not be 0; see handshake package
 
+  const char* env_libreplication_server_id = std::getenv("LIBREPLICATION_SERVER_ID");
+
+  if (env_libreplication_server_id != 0) {
+    try {
+      boost::uint32_t libreplication_server_id = boost::lexical_cast<boost::uint32_t>(env_libreplication_server_id);
+      prot_server_id = libreplication_server_id;
+    } catch (boost::bad_lexical_cast e) {
+      // XXX: nothing to do
+    }
+  }
+
   command_request_stream
           << prot_command
           << prot_binlog_offset


### PR DESCRIPTION
With this change, `server-id` will be configurable appropriately. 

With mysql-server v5.1, mysql-replication-listener cannot keep a connection with a same mysql-server if there are multiple mysql-replication-listener processes. It was because mysql-replication-listener is using a fixed server-id "1", but mysql-server v5.1 doesn't allow to use same server-id from multiple slaves. I confirmed that this issue doesn't occur with mysql-server v5.6.

For the fix, in the current code, one of server-id is configurable with `LIBREPLICATION_SERVER_ID` environment variable, but the other server-id was not configurable, so I added a same code to make it configurable.