### PR TITLE
@B658 potential fix for "Host not found" error happening on Smartling.  ...

### DIFF
--- a/src/tcp_driver.cpp
+++ b/src/tcp_driver.cpp
@@ -134,7 +134,10 @@ static int hash_sha1(boost::uint8_t *output, ...);
   try {
     endpoint_iterator=resolver.resolve(query);
   } catch (boost::system::system_error e) {
-    // maybe due to DNS server.  Try again assuming host is numeric.
+    /*
+      Maybe due to a DNS server issue.  Try again without DNS lookup, which
+      works if the given host is a numeric address.
+     */
     endpoint_iterator=resolver.resolve(query_nolookup);
   }
   tcp::resolver::iterator end;


### PR DESCRIPTION
...On their environment, event a numeric IP causes "Host not found" error.  If it's caused by an error during DNS lookup, bypassing it with numeric_host flag should solve the issue.  Needs to test on an environment where the issue happens.