### PR TITLE
Add boost version check for ssl_cipher api

### DIFF
--- a/include/binlog_socket.h
+++ b/include/binlog_socket.h
@@ -81,7 +81,11 @@ public:
   {
     if (is_ssl())
     {
+#if (BOOST_VERSION / 100000 >= 1) && (BOOST_VERSION / 100 % 1000 >= 47)
       SSL_set_cipher_list(m_ssl_socket->native_handle(), cipher_list.c_str());
+#else
+#warning "set_ssl_cipher api is disabled. Boost version needs to be 1.47 or later."
+#endif
     }
   }
 


### PR DESCRIPTION
Disable set_ssl_cipher api unless the boost version is 1.47 or later. This is because `native_handle()` is not supported by old boost library.

- How to get boost version
  - http://stackoverflow.com/questions/3708706/how-to-determine-the-boost-version-on-a-system