### PR TITLE
Feature/u1737 binlog checksum support

### DIFF
--- a/include/binlog_driver.h
+++ b/include/binlog_driver.h
@@ -31,7 +31,8 @@ class Binary_log_driver
 public:
   template <class FilenameT>
   Binary_log_driver(const FilenameT& filename = FilenameT(), unsigned int offset = 0)
-    : m_binlog_file_name(filename), m_binlog_offset(offset)
+    : m_binlog_file_name(filename), m_binlog_offset(offset),
+      m_checksum_alg(BINLOG_CHECKSUM_ALG_UNDEF)
   {
   }
 
@@ -101,6 +102,11 @@ protected:
    */
   unsigned long m_binlog_offset;
   std::string m_binlog_file_name;
+
+  /**
+   * Checksum algorythm
+   */
+  boost::uint8_t m_checksum_alg;
 };
 
 } // namespace mysql::system

--- a/include/binlog_event.h
+++ b/include/binlog_event.h
@@ -303,7 +303,7 @@ public:
 
 Binary_log_event *create_incident_event(unsigned int type, const char *message, unsigned long pos= 0);
 
-boost::uint8_t get_checksum_alg(const char* buf, boost::uint32_t len);
+boost::uint8_t get_checksum_alg(const char* payload_buf, boost::uint32_t len);
 
 inline boost::uint32_t version_product(const boost::uint8_t* version_split)
 {

--- a/include/protocol.h
+++ b/include/protocol.h
@@ -431,13 +431,13 @@ void proto_get_handshake_package(std::istream &is, struct st_handshake_package &
   Allocates a new event and copy the header. The caller must be responsible for
   releasing the allocated memory.
 */
-Query_event *proto_query_event(std::istream &is, Log_event_header *header);
-Rotate_event *proto_rotate_event(std::istream &is, Log_event_header *header);
-Incident_event *proto_incident_event(std::istream &is, Log_event_header *header);
-Row_event *proto_rows_event(std::istream &is, Log_event_header *header);
-Table_map_event *proto_table_map_event(std::istream &is, Log_event_header *header);
-Int_var_event *proto_intvar_event(std::istream &is, Log_event_header *header);
-User_var_event *proto_uservar_event(std::istream &is, Log_event_header *header);
+Query_event *proto_query_event(std::istream &is, Log_event_header *header, boost::uint32_t event_length);
+Rotate_event *proto_rotate_event(std::istream &is, Log_event_header *header, boost::uint32_t event_length);
+Incident_event *proto_incident_event(std::istream &is, Log_event_header *header, boost::uint32_t event_length);
+Row_event *proto_rows_event(std::istream &is, Log_event_header *header, boost::uint32_t event_length);
+Table_map_event *proto_table_map_event(std::istream &is, Log_event_header *header, boost::uint32_t event_length);
+Int_var_event *proto_intvar_event(std::istream &is, Log_event_header *header, boost::uint32_t event_length);
+User_var_event *proto_uservar_event(std::istream &is, Log_event_header *header, boost::uint32_t event_length);
 
 } // end namespace system
 } // end namespace mysql

--- a/include/tcp_driver.h
+++ b/include/tcp_driver.h
@@ -309,7 +309,7 @@ bool fetch_binlogs_name_and_size(Binlog_socket *binlog_socket, std::map<std::str
  * Sends a "SET @master_binlog_checksum=..." command to the server in order to
  * notify that the slave is aware of checksum.
  */
-bool set_master_binlog_checksum(Binlog_socket *binlog_socket);
+bool set_master_binlog_checksum(Binlog_socket *binlog_socket, bool &checksum_aware_master);
 
 /**
  * Fetch the master's binlog checksum type

--- a/include/tcp_driver.h
+++ b/include/tcp_driver.h
@@ -305,6 +305,16 @@ bool fetch_master_status(Binlog_socket *binlog_socket, std::string *filename, un
  * names and sizes in a map.
  */
 bool fetch_binlogs_name_and_size(Binlog_socket *binlog_socket, std::map<std::string, unsigned long> &binlog_map);
+/**
+ * Sends a "SET @master_binlog_checksum=..." command to the server in order to
+ * notify that the slave is aware of checksum.
+ */
+bool set_master_binlog_checksum(Binlog_socket *binlog_socket);
+
+/**
+ * Fetch the master's binlog checksum type
+ */
+bool fetch_master_binlog_checksum(Binlog_socket *binlog_socket, boost::uint8_t &checksum_alg);
 
 } }
 #endif	/* _TCP_DRIVER_H */

--- a/src/binlog_driver.cpp
+++ b/src/binlog_driver.cpp
@@ -36,34 +36,36 @@ Binary_log_event* Binary_log_driver::parse_event(std::istream &is,
    << ")\n";
   Binary_log_event *parsed_event= 0;
 
+  boost::uint32_t event_length= header->event_length;
+
   switch (header->type_code) {
     case TABLE_MAP_EVENT:
-      parsed_event= proto_table_map_event(is, header);
+      parsed_event= proto_table_map_event(is, header, event_length);
       break;
     case QUERY_EVENT:
-      parsed_event= proto_query_event(is, header);
+      parsed_event= proto_query_event(is, header, event_length);
       break;
     case INCIDENT_EVENT:
-      parsed_event= proto_incident_event(is, header);
+      parsed_event= proto_incident_event(is, header, event_length);
       break;
     case WRITE_ROWS_EVENT:
     case UPDATE_ROWS_EVENT:
     case DELETE_ROWS_EVENT:
-      parsed_event= proto_rows_event(is, header);
+      parsed_event= proto_rows_event(is, header, event_length);
       break;
     case ROTATE_EVENT:
       {
-        Rotate_event *rot= proto_rotate_event(is, header);
+        Rotate_event *rot= proto_rotate_event(is, header, event_length);
         m_binlog_file_name= rot->binlog_file;
         m_binlog_offset= (unsigned long)rot->binlog_pos;
         parsed_event= rot;
       }
       break;
     case INTVAR_EVENT:
-      parsed_event= proto_intvar_event(is, header);
+      parsed_event= proto_intvar_event(is, header, event_length);
       break;
     case USER_VAR_EVENT:
-      parsed_event= proto_uservar_event(is, header);
+      parsed_event= proto_uservar_event(is, header, event_length);
       break;
     case FORMAT_DESCRIPTION_EVENT:
       {

--- a/src/binlog_driver.cpp
+++ b/src/binlog_driver.cpp
@@ -30,9 +30,6 @@ Binary_log_event* Binary_log_driver::parse_event(boost::asio::streambuf
 Binary_log_event* Binary_log_driver::parse_event(std::istream &is,
                                                  Log_event_header *header)
 {
-  std::cout << "parse_event(eventid:" << (int)header->type_code
-   << ", next_position:" << header->next_position
-   << ")\n";
   Binary_log_event *parsed_event= 0;
 
   boost::uint32_t event_length= header->event_length;
@@ -72,33 +69,25 @@ Binary_log_event* Binary_log_driver::parse_event(std::istream &is,
       break;
     case FORMAT_DESCRIPTION_EVENT:
       {
-        std::cout << "FD event\n";
         std::string buf;
         // The length of the payload is unknown until we get the common header
         // length which is stored in the stream itself.  So, read the stream to
         // the location where the common header length is stored.
         boost::uint32_t len = ST_COMMON_HEADER_LEN_OFFSET + 1;
-        std::cout << "len: " << len << "\n";
         for (int i=0; i< len; i++)
         {
           char ch;
           is.get(ch);
-          std::cout << "ch:" << (int)ch << "\n";
           buf.push_back(ch);
           if (i == ST_COMMON_HEADER_LEN_OFFSET) {
             int common_header_len = ch;
             // Now we know the correct payload size.  update the length.
             len = header->event_length - common_header_len;
-            std::cout << "len(final): " << len << "\n";
           }
         }
-        std::cout << "buf: " << buf << "\n";
         is.seekg(-len, is.cur);
-        std::cout << "calling get_checksum_alg\n";
         m_checksum_alg= get_checksum_alg(buf.data(), len);
-        std::cout << "m_checksum_alg: " << (int)m_checksum_alg << "\n";
         parsed_event= new Binary_log_event(header);
-        std::cout << "FD done\n";
       }
       break;
     default:

--- a/src/binlog_driver.cpp
+++ b/src/binlog_driver.cpp
@@ -31,12 +31,15 @@ Binary_log_event* Binary_log_driver::parse_event(std::istream &is,
                                                  Log_event_header *header)
 {
   std::cout << "parse_event(eventid:" << (int)header->type_code
-   << ",file:" << m_binlog_file_name
-   << ",pos:" << m_binlog_offset
+   << ", next_position:" << header->next_position
    << ")\n";
   Binary_log_event *parsed_event= 0;
 
   boost::uint32_t event_length= header->event_length;
+
+  if (m_checksum_alg == BINLOG_CHECKSUM_ALG_CRC32) {
+    event_length -= CHECKSUM_CRC32_SIGNATURE_LEN;
+  }
 
   switch (header->type_code) {
     case TABLE_MAP_EVENT:
@@ -71,19 +74,29 @@ Binary_log_event* Binary_log_driver::parse_event(std::istream &is,
       {
         std::cout << "FD event\n";
         std::string buf;
-        boost::uint32_t len = header->event_length;
+        // The length of the payload is unknown until we get the common header
+        // length which is stored in the stream itself.  So, read the stream to
+        // the location where the common header length is stored.
+        boost::uint32_t len = ST_COMMON_HEADER_LEN_OFFSET + 1;
         std::cout << "len: " << len << "\n";
         for (int i=0; i< len; i++)
         {
           char ch;
           is.get(ch);
+          std::cout << "ch:" << (int)ch << "\n";
           buf.push_back(ch);
+          if (i == ST_COMMON_HEADER_LEN_OFFSET) {
+            int common_header_len = ch;
+            // Now we know the correct payload size.  update the length.
+            len = header->event_length - common_header_len;
+            std::cout << "len(final): " << len << "\n";
+          }
         }
         std::cout << "buf: " << buf << "\n";
         is.seekg(-len, is.cur);
         std::cout << "calling get_checksum_alg\n";
         m_checksum_alg= get_checksum_alg(buf.data(), len);
-        std::cout << "m_checksum_alg: " << m_checksum_alg << "\n";
+        std::cout << "m_checksum_alg: " << (int)m_checksum_alg << "\n";
         parsed_event= new Binary_log_event(header);
         std::cout << "FD done\n";
       }

--- a/src/binlog_event.cpp
+++ b/src/binlog_event.cpp
@@ -78,4 +78,41 @@ Binary_log_event * create_incident_event(unsigned int type, const char *message,
   return incident;
 }
 
+/* 
+   replication event checksum is introduced in the following "checksum-home" version.
+   The checksum-aware servers extract FD's version to decide whether the FD event
+   carries checksum info.
+*/
+const boost::uint8_t checksum_version_split[3]= {5, 6, 1};
+const boost::uint32_t checksum_version_product=
+  (checksum_version_split[0] * 256 + checksum_version_split[1]) * 256 +
+  checksum_version_split[2];
+
+/**
+   @param buf buffer holding serialized FD event
+   @param len netto (possible checksum is stripped off) length of the event buf
+   
+   @return  the version-safe checksum alg descriptor where zero
+            designates no checksum, 255 - the orginator is
+            checksum-unaware (effectively no checksum) and the actuall
+            [1-254] range alg descriptor.
+*/
+boost::uint8_t get_checksum_alg(const char* buf, boost::uint32_t len)
+{
+  boost::uint8_t ret;
+  char version[ST_SERVER_VER_LEN];
+  boost::uint8_t version_split[3];
+
+  memcpy(version, buf +
+         buf[LOG_EVENT_MINIMAL_HEADER_LEN + ST_COMMON_HEADER_LEN_OFFSET]
+         + ST_SERVER_VER_OFFSET, ST_SERVER_VER_LEN);
+  version[ST_SERVER_VER_LEN - 1]= 0;
+  
+  do_server_version_split(version, version_split);
+  ret= (version_product(version_split) < checksum_version_product) ?
+    (boost::uint8_t) BINLOG_CHECKSUM_ALG_UNDEF :
+    * (boost::uint8_t*) (buf + len - BINLOG_CHECKSUM_LEN - BINLOG_CHECKSUM_ALG_DESC_LEN);
+  return ret;
+}
+
 } // end namespace mysql

--- a/src/binlog_event.cpp
+++ b/src/binlog_event.cpp
@@ -106,15 +106,7 @@ boost::uint8_t get_checksum_alg(const char* payload_buf, boost::uint32_t len)
   memcpy(version, payload_buf + ST_SERVER_VER_OFFSET, ST_SERVER_VER_LEN);
   version[ST_SERVER_VER_LEN - 1]= 0;
   
-  std::cout << "version:" << version
-            << "\n";
   do_server_version_split(version, version_split);
-  std::cout << "version_split:" << (int)version_split[0]
-            << "," << (int)version_split[1]
-            << "," << (int)version_split[2]
-            << ",version:" << version_product(version_split)
-            << ", checksum_version_product:" << checksum_version_product
-            << "\n";
   ret= (version_product(version_split) < checksum_version_product) ?
     (boost::uint8_t) BINLOG_CHECKSUM_ALG_UNDEF :
     * (boost::uint8_t*) (payload_buf + len - BINLOG_CHECKSUM_LEN - BINLOG_CHECKSUM_ALG_DESC_LEN);

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -389,10 +389,6 @@ Rotate_event *proto_rotate_event(std::istream &is, Log_event_header *header, boo
   is >> prot_position
      >> prot_file_name;
 
-  std::cout << "file:" << rev->binlog_file
-  << "pos:" << rev->binlog_pos
-  << "\n";
-
   return rev;
 }
 

--- a/src/tcp_driver.cpp
+++ b/src/tcp_driver.cpp
@@ -411,8 +411,6 @@ static void proto_event_packet_header(boost::asio::streambuf &event_src, Log_eve
 
 void Binlog_tcp_driver::handle_net_packet(const boost::system::error_code& err, std::size_t bytes_transferred)
 {
-  std::cout << "bytes_transferred:" << bytes_transferred
-  << "\n";
   if (err)
   {
     Binary_log_event * ev= create_incident_event(175, err.message().c_str(), m_binlog_offset);
@@ -450,9 +448,6 @@ void Binlog_tcp_driver::handle_net_packet(const boost::system::error_code& err, 
      */
     //std::cerr << "Consuming event stream for header. Size before: " << m_event_stream_buffer.size() << std::endl;
     proto_event_packet_header(m_event_stream_buffer, m_waiting_event);
-    std::cout << "m_waiting_event type:" << (int)m_waiting_event->type_code
-    << "length:" << m_waiting_event->event_length
-    << std::endl;
     //std::cerr << " Size after: " << m_event_stream_buffer.size() << std::endl;
   }
 
@@ -465,8 +460,6 @@ void Binlog_tcp_driver::handle_net_packet(const boost::system::error_code& err, 
      Next we need to parse the payload buffer
      */
     std::istream is(&m_event_stream_buffer);
-    std::cout << "stream size:" << m_event_stream_buffer.size()
-    << "\n";
     Binary_log_event * event= parse_event(is, m_waiting_event);
 
     m_event_stream_buffer.consume(m_event_stream_buffer.size());
@@ -1041,8 +1034,6 @@ bool fetch_master_binlog_checksum(Binlog_socket *binlog_socket, boost::uint8_t &
   {
     std::string checksum_type_name;
     conv.to(checksum_type_name, row[0]);
-    std::cout << "checksum_type_name:" << checksum_type_name
-    << "\n";
 
     if (checksum_type_name == "NONE")
       checksum_alg = BINLOG_CHECKSUM_ALG_OFF;


### PR DESCRIPTION
Tested against the following MySQL servers as the replication master.

  MySQL 5.6.21 (non-RDS)
     binlog_checksum = CRC32  --> Success
     binlog_checksum = NONE   --> Success
     switch from a CRC32 binlog file to a no checksum binlog file --> Success
     switch from a no checksum binlog file to a CRC32 binlog file --> Success
  MySQL 5.5.43-0ubuntu0.14.04.1-log (non-RDS) (no checksum support)  --> Success

Will test RDS on integration env.
