### PR TITLE
@B850:R Chunk length was set incorrectly for a length encoded binary.

### DIFF
--- a/include/protocol.h
+++ b/include/protocol.h
@@ -301,8 +301,8 @@ public:
   virtual const char *data() { return m_data; }
   virtual void collapse_size(unsigned int new_size)
   {
-    //assert(new_size <= m_size);
-    memset((char *)m_data+new_size,'\0', m_size-new_size);
+    if (m_size-new_size > 0)
+      memset((char *)m_data+new_size,'\0', m_size-new_size);
     m_size= new_size;
   }
 private:


### PR DESCRIPTION
### The issue
The length of a length encoded integer chunk was set incorrectly.  It was smaller by 1 compared to the correct length.  This broke the processing of subsequent binlog data.

### The cause
A length encoded integer whose value is larger than 250 has an extra byte as a marker.  When decoding it to an integer, the marker byte must be excluded.
There was a bug in the logic to exclude the marker byte.  When excluding the marker byte, it was also subtracting a byte from the byte length of the chunk.  This is incorrect because the chunk length must indicate the length of the original binary data.