### PR TITLE
@B901:R  catch exception to prevent the thread's termination which ab…

### DIFF
--- a/src/tcp_driver.cpp
+++ b/src/tcp_driver.cpp
@@ -36,6 +36,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 #include <boost/lexical_cast.hpp>
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>
+#include <boost/chrono.hpp>
 
 #include "protocol.h"
 #include "binlog_event.h"
@@ -763,6 +764,7 @@ void Binlog_tcp_driver::start_event_loop()
         break;
       }
 
+      boost::this_thread::sleep_for(boost::chrono::seconds(1));
       reconnect();
     } catch (const std::exception& e) {
       std::cerr << "error in the event loop: " << e.what() << "\n";


### PR DESCRIPTION
…orts the main process.

In C++, an uncaught exception in a thread kills the entire process.  The main thread receives no exception when it happens.  To prevent it, I changed the code to catch all exceptions occurring in the thread and continue the thread.  
If the exception is network related, the main thread suffers from the same error and handles the error gracefully.
