### PR TITLE
Fix too many open files error and memory leaks when reconnecting many times

### DIFF
--- a/include/binlog_api.h
+++ b/include/binlog_api.h
@@ -104,7 +104,9 @@ private:
   std::string m_binlog_file;
 public:
   Binary_log(system::Binary_log_driver *drv);
-  ~Binary_log() {}
+  ~Binary_log() {
+    delete(m_driver);
+  }
 
   int connect();
 

--- a/include/binlog_driver.h
+++ b/include/binlog_driver.h
@@ -36,7 +36,7 @@ public:
   {
   }
 
-  ~Binary_log_driver() {}
+  virtual ~Binary_log_driver() {}
 
   /**
    * Connect to the binary log using previously declared connection parameters

--- a/src/binary_log.cpp
+++ b/src/binary_log.cpp
@@ -114,7 +114,13 @@ unsigned long Binary_log::get_position(std::string &filename)
 
 int Binary_log::connect()
 {
-  return m_driver->connect();
+  try {
+    return m_driver->connect();
+  }catch (const std::exception& e) {
+    delete(m_driver);
+    m_driver = NULL;
+    throw;
+  }
 }
 
 int Binary_log::set_ssl_ca(const std::string& filepath)

--- a/src/tcp_driver.cpp
+++ b/src/tcp_driver.cpp
@@ -148,6 +148,7 @@ static int hash_sha1(boost::uint8_t *output, ...);
     boost::system::error_code ec;
     boost::asio::ip::address addr = boost::asio::ip::address::from_string(host, ec);
     if (ec) {
+      delete(binlog_socket);
       throw std::runtime_error("Host `" + host + "` not found");
     }
     tcp::endpoint ep(addr, port);
@@ -170,6 +171,7 @@ static int hash_sha1(boost::uint8_t *output, ...);
 
   if (error)
   {
+    delete(binlog_socket);
     throw std::runtime_error("Boost error: " + error.message());
   }
 
@@ -256,6 +258,7 @@ static int hash_sha1(boost::uint8_t *output, ...);
   unsigned char packet_no;
   if (proto_read_package_header(binlog_socket, server_messages, &packet_length, &packet_no))
   {
+    delete(binlog_socket);
     throw std::runtime_error("Invalid package header");
   }
 
@@ -285,8 +288,10 @@ static int hash_sha1(boost::uint8_t *output, ...);
   /*
    * Authenticate
    */
-  if (authenticate(binlog_socket, user, passwd, handshake_package))
+  if (authenticate(binlog_socket, user, passwd, handshake_package)){
+    delete(binlog_socket);
     throw std::runtime_error("Authentication failed.");
+  }
 
   /*
    * Register slave to master


### PR DESCRIPTION
I fixed the "too many open files" error that I was seeing after reconnecting many times in a row.  The fix was to delete the tcp driver when an exception is encountered.  This however, requires a fix to ruby-binlog as well since the is_closed? method was returning false even after the tcp driver was deleted.

I also noticed that memory increased during reconnects as well, so I fixed several memory leaks that I found while debugging.

