### PR TITLE
fix pthread_mutex_destroy core dumps when ruby exits

### DIFF
--- a/include/tcp_driver.h
+++ b/include/tcp_driver.h
@@ -54,6 +54,12 @@ public:
 
     ~Binlog_tcp_driver()
     {
+      disconnect();
+      m_io_service.post(boost::bind(&Binlog_tcp_driver::shutdown, this));
+      if (m_event_loop){
+        m_event_loop->join();
+        delete m_event_loop;
+      }
         delete m_event_queue;
         delete m_socket;
     }


### PR DESCRIPTION
I noticed after my previous fixes, sometimes when my ruby program exited, I would get the following error: 
ruby: /usr/include/boost/thread/pthread/condition_variable.hpp:168: boost::condition_variable_any::~condition_variable_any(): Assertion `!pthread_mutex_destroy(&internal_mutex)' failed.
Aborted (core dumped)

To fix this error, during destruction of the tcp driver, I have it clean up more stuff (i.e. run disconnect(), wait for event loop and io service thread to shutdown, and then delete the event loop).

On my mac, this error was intermittent, but on my Ubuntu server it happened every time. After this fix, it doesn't happen anymore on either of my machines.